### PR TITLE
Invoke CLI Octave also in dependency checks.

### DIFF
--- a/octaveh2matlabh
+++ b/octaveh2matlabh
@@ -657,7 +657,7 @@ find_and_check_macro_file() {
 
         # Use Octave to get the path to the file containing the Octave
         # documentation specific Texinfo macros.
-        echo_cmd_fatal octave>/dev/null;
+        echo_cmd_fatal octave-cli>/dev/null;
         set +o errexit
         F=texi_macros_file;
         MACROS_FILE_OPT="$(octave-cli -q -H --norc \

--- a/octaveh2matlabh_recursive
+++ b/octaveh2matlabh_recursive
@@ -281,7 +281,7 @@ dependency_check() {
     echo_cmd_fatal mkdir>/dev/null;
     echo_cmd_fatal cp>/dev/null;
     echo_cmd_fatal $O2M>/dev/null;
-    echo_cmd_fatal octave>/dev/null;
+    echo_cmd_fatal octave-cli>/dev/null;
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
as specified in discussion
thierr26:
"Strictly speaking, you should also update the dependency checks (i.e. substitute "octave" with "octave-cli" on line 660 in octaveh2matlabh and on line 284 in octaveh2matlabh_recursive)."